### PR TITLE
fixes issue: No project found with name 'undefined'.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,11 @@ This plugin provides Botkit developers a way to use the [rasa NLU](https://rasa.
 
 
 ```
-var rasa = require('botkit-rasa')({rasa_uri: 'http://localhost:5000'});
+var rasa = require('botkit-rasa')({
+    rasa_uri: 'http://localhost:5000',
+    rasa_project: 'my_bot',
+    rasa_model: 'my_model'
+});
 controller.middleware.receive.use(rasa.receive);
 
 controller.hears(['my_intent'],'message_received', rasa.hears, function(bot, message) {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -10,6 +10,10 @@ module.exports = config => {
     config.rasa_uri = 'http://localhost:5000'
   }
 
+  if (!config.project) {
+    config.rasa_project = 'default'
+  }
+
   var middleware = {
     receive: (bot, message, next) => {
       if (!message.text || message.is_echo) {
@@ -22,7 +26,9 @@ module.exports = config => {
         method: 'POST',
         uri: `${config.rasa_uri}/parse`,
         body: {
-          q: message.text
+          q: message.text,
+          project: config.rasa_project,
+          model: config.rasa_model
         },
         json: true
       }


### PR DESCRIPTION
Since I was using Rasa NLU 0.12.x, I got the following exception:

`Unhandled rejection StatusCodeError: 404 - {"error":"No project found with name 'undefined'."}`

The root cause was Rasa NLU server requires to pass more params including `project` and `model`. For example:

```bash
curl -XPOST localhost:5000/parse -d '{"q":"hello there", "project": "my_restaurant_search_bot", "model": "<model_XXXXXX>"}'
```

Reference: https://nlu.rasa.com/http.html